### PR TITLE
Feature/smar-2708 add additional configuration for deployments in helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tgz
 *.zip
+.devcontainer/
+egid.values.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added test pods supporting `helm test` command
   - There are multiple test pods, some of which run based on what is possible to test in the selected chart configuration
 - Added support for tenant management API (ingress)
+- Make deployment revisionHistoryLimit and updateStrategy configurable via values
 
 ### Changed
 - Bumped version of `sf-tenant-management` subchart

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ metadata:
 | readonlyApi.nodeSelector | object | `{}` |  |
 | readonlyApi.proxyContainer.resources | object | `{}` |  |
 | readonlyApi.tolerations | list | `[]` |  |
+| revisionHistoryLimit | int | `10` | Common revisionHistoryLimit for all deployments |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Set this toggle to false to opt out of automounting API credentials for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
@@ -574,6 +575,7 @@ metadata:
 | tests.podAnnotations | object | `{}` | Annotations for test pods |
 | tests.podLabels | object | `{}` | Additional labels for test pods |
 | tests.tolerations | list | `[]` |  |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Common updateStrategy for all deployments # e.g: # updateStrategy: #  type: RollingUpdate #  rollingUpdate: #    maxSurge: 25% #    maxUnavailable: 25% # |
 | wlStreamPopulationJob.enabled | bool | `false` |  |
 | wlStreamPopulationJob.image.digest | string | `nil` | Overrides the image tag with an image digest |
 | wlStreamPopulationJob.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ metadata:
 | tests.podAnnotations | object | `{}` | Annotations for test pods |
 | tests.podLabels | object | `{}` | Additional labels for test pods |
 | tests.tolerations | list | `[]` |  |
-| updateStrategy | object | `{}` | Common updateStrategy for all deployments # e.g: # updateStrategy: #  type: RollingUpdate #  rollingUpdate: #    maxSurge: 25% #    maxUnavailable: 25% # |
+| updateStrategy | object | `{}` | Common updateStrategy for all deployments |
 | wlStreamPopulationJob.enabled | bool | `false` |  |
 | wlStreamPopulationJob.image.digest | string | `nil` | Overrides the image tag with an image digest |
 | wlStreamPopulationJob.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ metadata:
 | readonlyApi.nodeSelector | object | `{}` |  |
 | readonlyApi.proxyContainer.resources | object | `{}` |  |
 | readonlyApi.tolerations | list | `[]` |  |
-| revisionHistoryLimit | int | `10` | Common revisionHistoryLimit for all deployments |
+| revisionHistoryLimit | string | `nil` | Common revisionHistoryLimit for all deployments |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Set this toggle to false to opt out of automounting API credentials for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
@@ -575,7 +575,7 @@ metadata:
 | tests.podAnnotations | object | `{}` | Annotations for test pods |
 | tests.podLabels | object | `{}` | Additional labels for test pods |
 | tests.tolerations | list | `[]` |  |
-| updateStrategy | object | `{"type":"RollingUpdate"}` | Common updateStrategy for all deployments # e.g: # updateStrategy: #  type: RollingUpdate #  rollingUpdate: #    maxSurge: 25% #    maxUnavailable: 25% # |
+| updateStrategy | object | `{}` | Common updateStrategy for all deployments # e.g: # updateStrategy: #  type: RollingUpdate #  rollingUpdate: #    maxSurge: 25% #    maxUnavailable: 25% # |
 | wlStreamPopulationJob.enabled | bool | `false` |  |
 | wlStreamPopulationJob.image.digest | string | `nil` | Overrides the image tag with an image digest |
 | wlStreamPopulationJob.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |

--- a/templates/_matcher.tpl
+++ b/templates/_matcher.tpl
@@ -21,8 +21,9 @@ metadata:
 spec:
   replicas: {{ .Values.matcher.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/_matcher.tpl
+++ b/templates/_matcher.tpl
@@ -20,6 +20,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.matcher.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/_matcher.tpl
+++ b/templates/_matcher.tpl
@@ -20,7 +20,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.matcher.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.api.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/auth-api-deployment.yaml
+++ b/templates/auth-api-deployment.yaml
@@ -19,8 +19,9 @@ spec:
   replicas: {{ .Values.authApi.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/auth-api-deployment.yaml
+++ b/templates/auth-api-deployment.yaml
@@ -18,6 +18,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.api.enabled ) }}
   replicas: {{ .Values.authApi.replicas }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/auth-api-deployment.yaml
+++ b/templates/auth-api-deployment.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.api.enabled ) }}
   replicas: {{ .Values.authApi.replicas }}
   {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/countly-publisher-deployment.yaml
+++ b/templates/countly-publisher-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/countly-publisher-deployment.yaml
+++ b/templates/countly-publisher-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/countly-publisher-deployment.yaml
+++ b/templates/countly-publisher-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/db-synchronization-leader-deployment.yaml
+++ b/templates/db-synchronization-leader-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.dbSynchronizationLeader.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/db-synchronization-leader-deployment.yaml
+++ b/templates/db-synchronization-leader-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.dbSynchronizationLeader.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/db-synchronization-leader-deployment.yaml
+++ b/templates/db-synchronization-leader-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.dbSynchronizationLeader.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/detector-deployment.yaml
+++ b/templates/detector-deployment.yaml
@@ -17,7 +17,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.detector.enabled ) }}
   replicas: {{ .Values.detector.replicas }}
   {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/detector-deployment.yaml
+++ b/templates/detector-deployment.yaml
@@ -6,8 +6,6 @@ metadata:
   name: {{ $name | quote }}
   labels:
     {{- include "smartface.detector.labels" . | nindent 4 }}
-    {{- if .Values.updateStrategy }}
-    debug: "ano"
     {{- end }}
   annotations:
     {{- with .Values.annotations }}

--- a/templates/detector-deployment.yaml
+++ b/templates/detector-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ $name | quote }}
   labels:
     {{- include "smartface.detector.labels" . | nindent 4 }}
-    {{- end }}
   annotations:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/templates/detector-deployment.yaml
+++ b/templates/detector-deployment.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.detector.enabled ) }}
   replicas: {{ .Values.detector.replicas }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/detector-deployment.yaml
+++ b/templates/detector-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ $name | quote }}
   labels:
     {{- include "smartface.detector.labels" . | nindent 4 }}
+    {{- if .Values.updateStrategy }}
+    debug: "ano"
+    {{- end }}
   annotations:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -18,8 +21,9 @@ spec:
   replicas: {{ .Values.detector.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/access-controller-deployment.yaml
+++ b/templates/edge-streams/access-controller-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/access-controller-deployment.yaml
+++ b/templates/edge-streams/access-controller-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/access-controller-deployment.yaml
+++ b/templates/edge-streams/access-controller-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/edge-streams/base-deployment.yaml
+++ b/templates/edge-streams/base-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/base-deployment.yaml
+++ b/templates/edge-streams/base-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/base-deployment.yaml
+++ b/templates/edge-streams/base-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/edge-streams/edge-stream-processor-deployment.yaml
+++ b/templates/edge-streams/edge-stream-processor-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.edgeStreamProcessor.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/edge-stream-processor-deployment.yaml
+++ b/templates/edge-streams/edge-stream-processor-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.edgeStreamProcessor.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/edge-streams/edge-stream-processor-deployment.yaml
+++ b/templates/edge-streams/edge-stream-processor-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.edgeStreamProcessor.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/edge-streams-state-sync-deployment.yaml
+++ b/templates/edge-streams/edge-streams-state-sync-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/edge-streams-state-sync-deployment.yaml
+++ b/templates/edge-streams/edge-streams-state-sync-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/edge-streams-state-sync-deployment.yaml
+++ b/templates/edge-streams/edge-streams-state-sync-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/edge-streams/face-matcher-deployment.yaml
+++ b/templates/edge-streams/face-matcher-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.faceMatcher.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/edge-streams/face-matcher-deployment.yaml
+++ b/templates/edge-streams/face-matcher-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.faceMatcher.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/face-matcher-deployment.yaml
+++ b/templates/edge-streams/face-matcher-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.faceMatcher.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/stream-data-db-worker-deployment.yaml
+++ b/templates/edge-streams/stream-data-db-worker-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.streamDataDbWorker.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/stream-data-db-worker-deployment.yaml
+++ b/templates/edge-streams/stream-data-db-worker-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.streamDataDbWorker.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/edge-streams/stream-data-db-worker-deployment.yaml
+++ b/templates/edge-streams/stream-data-db-worker-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.streamDataDbWorker.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/extractor-deployment.yaml
+++ b/templates/extractor-deployment.yaml
@@ -17,7 +17,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.extractor.enabled ) }}
   replicas: {{ .Values.extractor.replicas }}
   {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/extractor-deployment.yaml
+++ b/templates/extractor-deployment.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if not (and (or .Values.autoscaling.cron.enabled .Values.autoscaling.rmq.enabled) .Values.autoscaling.extractor.enabled ) }}
   replicas: {{ .Values.extractor.replicas }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/extractor-deployment.yaml
+++ b/templates/extractor-deployment.yaml
@@ -18,8 +18,9 @@ spec:
   replicas: {{ .Values.extractor.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/graphql-deployment.yaml
+++ b/templates/graphql-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: {{ .Values.graphqlApi.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/graphql-deployment.yaml
+++ b/templates/graphql-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.graphqlApi.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/graphql-deployment.yaml
+++ b/templates/graphql-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.graphqlApi.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/liveness-deployment.yaml
+++ b/templates/liveness-deployment.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.liveness.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/liveness-deployment.yaml
+++ b/templates/liveness-deployment.yaml
@@ -16,8 +16,9 @@ metadata:
 spec:
   replicas: {{ .Values.liveness.replicas }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/liveness-deployment.yaml
+++ b/templates/liveness-deployment.yaml
@@ -15,7 +15,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.liveness.replicas }}
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/readonly-api/api-nginx-deployment.yaml
+++ b/templates/readonly-api/api-nginx-deployment.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.readonlyApi.noAuthName | quote }}
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       app: {{ .Values.readonlyApi.noAuthName | quote }}

--- a/templates/readonly-api/api-nginx-deployment.yaml
+++ b/templates/readonly-api/api-nginx-deployment.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ .Values.readonlyApi.noAuthName | quote }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.readonlyApi.noAuthName | quote }}

--- a/templates/readonly-api/api-nginx-deployment.yaml
+++ b/templates/readonly-api/api-nginx-deployment.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.readonlyApi.noAuthName | quote }}
 spec:
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/readonly-api/auth-api-nginx-deployment.yaml
+++ b/templates/readonly-api/auth-api-nginx-deployment.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ .Values.readonlyApi.authName | quote }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.readonlyApi.authName | quote }}

--- a/templates/readonly-api/auth-api-nginx-deployment.yaml
+++ b/templates/readonly-api/auth-api-nginx-deployment.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.readonlyApi.authName | quote }}
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       app: {{ .Values.readonlyApi.authName | quote }}

--- a/templates/readonly-api/auth-api-nginx-deployment.yaml
+++ b/templates/readonly-api/auth-api-nginx-deployment.yaml
@@ -4,7 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.readonlyApi.authName | quote }}
 spec:
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/templates/station-deployment.yaml
+++ b/templates/station-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  strategy:
-    type: {{ .Values.updateStrategy.type }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/station-deployment.yaml
+++ b/templates/station-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- $selectorLabels | nindent 6 }}

--- a/templates/station-deployment.yaml
+++ b/templates/station-deployment.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -22,13 +22,6 @@ serviceLabels: {}
 # -- Common revisionHistoryLimit for all deployments
 revisionHistoryLimit:
 # -- Common updateStrategy for all deployments
-## e.g:
-## updateStrategy:
-##  type: RollingUpdate
-##  rollingUpdate:
-##    maxSurge: 25%
-##    maxUnavailable: 25%
-##
 updateStrategy: {}
 
 # -- docker secrets used to pull images with

--- a/values.yaml
+++ b/values.yaml
@@ -6,9 +6,6 @@ global:
   image:
     # -- Overrides the Docker registry globally for all images
     registry: "registry.gitlab.com"
-  deployments:
-    revisionHistoryLimit: 10
-    strategy: "RollingUpdate"
 
 # -- Overrides the chart's name
 nameOverride: null
@@ -22,6 +19,11 @@ podLabels: {}
 serviceAnnotations: {}
 # -- Common labels for all services
 serviceLabels: {}
+# -- Common revisionHistoryLimit for all deployments
+revisionHistoryLimit: 10
+# -- Common updateStrategy for all deployments
+updateStrategy:
+  type: "RollingUpdate"
 
 # -- docker secrets used to pull images with
 imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,9 @@ global:
   image:
     # -- Overrides the Docker registry globally for all images
     registry: "registry.gitlab.com"
+  deployments:
+    revisionHistoryLimit: 10
+    strategy: "RollingUpdate"
 
 # -- Overrides the chart's name
 nameOverride: null

--- a/values.yaml
+++ b/values.yaml
@@ -22,6 +22,13 @@ serviceLabels: {}
 # -- Common revisionHistoryLimit for all deployments
 revisionHistoryLimit: 10
 # -- Common updateStrategy for all deployments
+## e.g:
+## updateStrategy:
+##  type: RollingUpdate
+##  rollingUpdate:
+##    maxSurge: 25%
+##    maxUnavailable: 25%
+##
 updateStrategy:
   type: "RollingUpdate"
 

--- a/values.yaml
+++ b/values.yaml
@@ -20,7 +20,7 @@ serviceAnnotations: {}
 # -- Common labels for all services
 serviceLabels: {}
 # -- Common revisionHistoryLimit for all deployments
-revisionHistoryLimit: 10
+revisionHistoryLimit:
 # -- Common updateStrategy for all deployments
 ## e.g:
 ## updateStrategy:
@@ -29,8 +29,7 @@ revisionHistoryLimit: 10
 ##    maxSurge: 25%
 ##    maxUnavailable: 25%
 ##
-updateStrategy:
-  type: "RollingUpdate"
+updateStrategy: {}
 
 # -- docker secrets used to pull images with
 imagePullSecrets:


### PR DESCRIPTION
Requirment was that we should be able to configure via helmchart those two deployment properites:

updateStrategy
revisionHistoryLimit

It was added to values file as:

revisionHistoryLimit:
updateStrategy: {}

when they are empty, default value is used